### PR TITLE
Fix height for non-tick style scalebars

### DIFF
--- a/python/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
+++ b/python/core/auto_generated/scalebar/qgsscalebarrenderer.sip.in
@@ -25,17 +25,6 @@ custom labeling.
 %End
   public:
 
-    struct ScaleBarContext
-    {
-
-      double segmentWidth;
-
-      QSizeF size;
-
-      double scale;
-
-    };
-
     enum class Flag
     {
       FlagUsesLineSymbol,
@@ -55,6 +44,19 @@ custom labeling.
     };
     typedef QFlags<QgsScaleBarRenderer::Flag> Flags;
 
+
+    struct ScaleBarContext
+    {
+
+      double segmentWidth;
+
+      QSizeF size;
+
+      double scale;
+
+      Flags flags;
+
+    };
 
     QgsScaleBarRenderer();
 %Docstring

--- a/src/core/layout/qgslayoutitemscalebar.cpp
+++ b/src/core/layout/qgslayoutitemscalebar.cpp
@@ -386,6 +386,7 @@ QgsScaleBarRenderer::ScaleBarContext QgsLayoutItemScaleBar::createScaleContext()
   scaleContext.size = rect().size();
   scaleContext.segmentWidth = mSegmentMillimeters;
   scaleContext.scale = mMap ? mMap->scale() : 1.0;
+  scaleContext.flags = mStyle->flags();
   return scaleContext;
 }
 

--- a/src/core/scalebar/qgsscalebarrenderer.cpp
+++ b/src/core/scalebar/qgsscalebarrenderer.cpp
@@ -47,7 +47,15 @@ void QgsScaleBarRenderer::drawDefaultLabels( QgsRenderContext &context, const Qg
 
   double scaledBoxContentSpace = context.convertToPainterUnits( settings.boxContentSpace(), QgsUnitTypes::RenderMillimeters );
   double scaledLabelBarSpace = context.convertToPainterUnits( settings.labelBarSpace(), QgsUnitTypes::RenderMillimeters );
-  double scaledHeight = context.convertToPainterUnits( settings.height() > settings.subdivisionsHeight() ? settings.height() : settings.subdivisionsHeight(), QgsUnitTypes::RenderMillimeters );
+  double scaledHeight;
+  if ( ( scaleContext.flags & Flag::FlagUsesSubdivisions ) && ( settings.subdivisionsHeight() > settings.height() ) )
+  {
+    scaledHeight = context.convertToPainterUnits( settings.subdivisionsHeight(), QgsUnitTypes::RenderMillimeters );
+  }
+  else
+  {
+    scaledHeight = context.convertToPainterUnits( settings.height(), QgsUnitTypes::RenderMillimeters );
+  }
 
   double currentLabelNumber = 0.0;
 
@@ -263,7 +271,16 @@ QSizeF QgsScaleBarRenderer::calculateBoxSize( QgsRenderContext &context, const Q
   lineWidth /= context.convertToPainterUnits( 1, QgsUnitTypes::RenderMillimeters );
 
   double width = firstLabelWidth + totalBarLength + 2 * lineWidth + largestLabelWidth + 2 * settings.boxContentSpace();
-  double height = ( settings.height() > settings.subdivisionsHeight() ? settings.height() : settings.subdivisionsHeight() ) + settings.labelBarSpace() + 2 * settings.boxContentSpace() + QgsLayoutUtils::fontAscentMM( font );
+  double height;
+  if ( ( scaleContext.flags & Flag::FlagUsesSubdivisions ) && ( settings.subdivisionsHeight() > settings.height() ) )
+  {
+    height = settings.subdivisionsHeight();
+  }
+  else
+  {
+    height = settings.height();
+  }
+  height += settings.labelBarSpace() + 2 * settings.boxContentSpace() + QgsLayoutUtils::fontAscentMM( font );
 
   return QSizeF( width, height );
 }

--- a/src/core/scalebar/qgsscalebarrenderer.h
+++ b/src/core/scalebar/qgsscalebarrenderer.h
@@ -40,6 +40,29 @@ class CORE_EXPORT QgsScaleBarRenderer
   public:
 
     /**
+     * Flags which control scalebar renderer behavior.
+     * \since QGIS 3.14
+     */
+    enum class Flag
+    {
+      FlagUsesLineSymbol = 1 << 0, //!< Renderer utilizes the scalebar line symbol (see QgsScaleBarSettings::lineSymbol() )
+      FlagUsesFillSymbol = 1 << 1, //!< Renderer utilizes the scalebar fill symbol (see QgsScaleBarSettings::fillSymbol() )
+      FlagUsesAlternateFillSymbol = 1 << 2, //!< Renderer utilizes the alternate scalebar fill symbol (see QgsScaleBarSettings::alternateFillSymbol() )
+      FlagRespectsUnits = 1 << 3, //!< Renderer respects the QgsScaleBarSettings::units() setting
+      FlagRespectsMapUnitsPerScaleBarUnit = 1 << 4, //!< Renderer respects the QgsScaleBarSettings::mapUnitsPerScaleBarUnit() setting
+      FlagUsesUnitLabel = 1 << 5, //!< Renderer uses the QgsScaleBarSettings::unitLabel() setting
+      FlagUsesSegments = 1 << 6, //!< Renderer uses the scalebar segments
+      FlagUsesLabelBarSpace = 1 << 7, //!< Renderer uses the QgsScaleBarSettings::labelBarSpace() setting
+      FlagUsesLabelVerticalPlacement = 1 << 8, //!< Renderer uses the QgsScaleBarSettings::labelVerticalPlacement() setting
+      FlagUsesLabelHorizontalPlacement = 1 << 8, //!< Renderer uses the QgsScaleBarSettings::labelHorizontalPlacement() setting
+      FlagUsesAlignment = 1 << 9, //!< Renderer uses the QgsScaleBarSettings::alignment() setting
+      FlagUsesSubdivisions = 1 << 10, //!< Renderer uses the scalebar subdivisions
+      FlagUsesDivisionSymbol = 1 << 11, //!< Renderer utilizes the scalebar division symbol (see QgsScaleBarSettings::divisionLineSymbol() )
+      FlagUsesSubdivisionSymbol = 1 << 12, //!< Renderer utilizes the scalebar subdivision symbol (see QgsScaleBarSettings::subdivisionLineSymbol() )
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
+    /**
      * Contains parameters regarding scalebar calculations.
      * \note The need to attribute the parameters vary depending on the targeted scalebar.
      */
@@ -62,30 +85,10 @@ class CORE_EXPORT QgsScaleBarRenderer
       //! Scale denominator
       double scale { 1.0 };
 
-    };
+      //! Scalebar renderer flags
+      Flags flags;
 
-    /**
-     * Flags which control scalebar renderer behavior.
-     * \since QGIS 3.14
-     */
-    enum class Flag
-    {
-      FlagUsesLineSymbol = 1 << 0, //!< Renderer utilizes the scalebar line symbol (see QgsScaleBarSettings::lineSymbol() )
-      FlagUsesFillSymbol = 1 << 1, //!< Renderer utilizes the scalebar fill symbol (see QgsScaleBarSettings::fillSymbol() )
-      FlagUsesAlternateFillSymbol = 1 << 2, //!< Renderer utilizes the alternate scalebar fill symbol (see QgsScaleBarSettings::alternateFillSymbol() )
-      FlagRespectsUnits = 1 << 3, //!< Renderer respects the QgsScaleBarSettings::units() setting
-      FlagRespectsMapUnitsPerScaleBarUnit = 1 << 4, //!< Renderer respects the QgsScaleBarSettings::mapUnitsPerScaleBarUnit() setting
-      FlagUsesUnitLabel = 1 << 5, //!< Renderer uses the QgsScaleBarSettings::unitLabel() setting
-      FlagUsesSegments = 1 << 6, //!< Renderer uses the scalebar segments
-      FlagUsesLabelBarSpace = 1 << 7, //!< Renderer uses the QgsScaleBarSettings::labelBarSpace() setting
-      FlagUsesLabelVerticalPlacement = 1 << 8, //!< Renderer uses the QgsScaleBarSettings::labelVerticalPlacement() setting
-      FlagUsesLabelHorizontalPlacement = 1 << 8, //!< Renderer uses the QgsScaleBarSettings::labelHorizontalPlacement() setting
-      FlagUsesAlignment = 1 << 9, //!< Renderer uses the QgsScaleBarSettings::alignment() setting
-      FlagUsesSubdivisions = 1 << 10, //!< Renderer uses the scalebar subdivisions
-      FlagUsesDivisionSymbol = 1 << 11, //!< Renderer utilizes the scalebar division symbol (see QgsScaleBarSettings::divisionLineSymbol() )
-      FlagUsesSubdivisionSymbol = 1 << 12, //!< Renderer utilizes the scalebar subdivision symbol (see QgsScaleBarSettings::subdivisionLineSymbol() )
     };
-    Q_DECLARE_FLAGS( Flags, Flag )
 
     /**
      * Constructor for QgsScaleBarRenderer.


### PR DESCRIPTION
## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
