### PR TITLE
Fix QgsDoubleValidator for negative sign in some locales

### DIFF
--- a/src/gui/qgsdoublevalidator.cpp
+++ b/src/gui/qgsdoublevalidator.cpp
@@ -25,7 +25,7 @@
 
 #include "qgsdoublevalidator.h"
 
-const QString PERMISSIVE_DOUBLE = R"(-?[\d]{0,1000}([\.%1][\d]{0,1000})?(e[+-]?[\d]{0,%2})?)";
+const QString PERMISSIVE_DOUBLE = R"([-−]?[\d]{0,1000}([\.%1][\d]{0,1000})?(e[+-−]?[\d]{0,%2})?)";
 
 QgsDoubleValidator::QgsDoubleValidator( QObject *parent )
   : QRegularExpressionValidator( parent )

--- a/tests/src/gui/testqgsdoublevalidator.cpp
+++ b/tests/src/gui/testqgsdoublevalidator.cpp
@@ -58,25 +58,26 @@ void TestQgsDoubleValidator::validate_data()
 {
   QTest::addColumn<QString>( "actualState" );
   QTest::addColumn<int>( "expState" );
+  QTest::addColumn<bool>( "negative" );
 
-  QTest::newRow( "C decimal" ) << QString( "4cd6" ) << int( QValidator::Acceptable );
-  QTest::newRow( "locale decimal" ) << QString( "4ld6" ) << int( QValidator::Acceptable );
-  QTest::newRow( "locale decimal" ) << QString( "4444ld6" ) << int( QValidator::Acceptable );
-  QTest::newRow( "C negative C decimal" ) << QString( "cn4cd6" ) << int( QValidator::Acceptable );
-  QTest::newRow( "locale negative locale decimal" ) << QString( "ln4ld6" ) << int( QValidator::Acceptable );
-  QTest::newRow( "locale negative locale decimal" ) << QString( "ln4444ld6" ) << int( QValidator::Acceptable );
+  QTest::newRow( "C decimal" ) << QString( "4cd6" ) << int( QValidator::Acceptable ) << false;
+  QTest::newRow( "locale decimal" ) << QString( "4ld6" ) << int( QValidator::Acceptable ) << false;
+  QTest::newRow( "locale decimal" ) << QString( "4444ld6" ) << int( QValidator::Acceptable ) << false;
+  QTest::newRow( "C negative C decimal" ) << QString( "cn4cd6" ) << int( QValidator::Acceptable ) << true;
+  QTest::newRow( "locale negative locale decimal" ) << QString( "ln4ld6" ) << int( QValidator::Acceptable ) << true;
+  QTest::newRow( "locale negative locale decimal" ) << QString( "ln4444ld6" ) << int( QValidator::Acceptable ) << true;
 
   // QgsDoubleValidator doesn't expect group separator but it tolerates it,
   // so the result will be QValidator::Intermediate and not QValidator::Acceptable
-  QTest::newRow( "locale group separator + locale decimal" ) << QString( "4lg444ld6" ) << int( QValidator::Intermediate );
-  QTest::newRow( "locale group separator misplaced + locale decimal" ) << QString( "44lg44ld6" ) << int( QValidator::Intermediate );
-  QTest::newRow( "locale group separator + c decimal" ) << QString( "4lg444cd6" ) << int( QValidator::Invalid );
-  QTest::newRow( "c group separator + locale decimal" ) << QString( "4cg444ld6" ) << int( QValidator::Invalid );
-  QTest::newRow( "c group separator + c decimal" ) << QString( "4cg444cd6" ) << int( QValidator::Intermediate );
+  QTest::newRow( "locale group separator + locale decimal" ) << QString( "4lg444ld6" ) << int( QValidator::Intermediate ) << false;
+  QTest::newRow( "locale group separator misplaced + locale decimal" ) << QString( "44lg44ld6" ) << int( QValidator::Intermediate ) << false;
+  QTest::newRow( "locale group separator + c decimal" ) << QString( "4lg444cd6" ) << int( QValidator::Invalid ) << false;
+  QTest::newRow( "c group separator + locale decimal" ) << QString( "4cg444ld6" ) << int( QValidator::Invalid ) << false;
+  QTest::newRow( "c group separator + c decimal" ) << QString( "4cg444cd6" ) << int( QValidator::Intermediate ) << false;
 
-  QTest::newRow( "outside the range + local decimal" ) << QString( "3ld6" ) << int( QValidator::Intermediate );
-  QTest::newRow( "outside the range + c decimal" ) << QString( "3cd6" ) << int( QValidator::Intermediate );
-  QTest::newRow( "string" ) << QString( "string" ) << int( QValidator::Invalid );
+  QTest::newRow( "outside the range + local decimal" ) << QString( "3ld6" ) << int( QValidator::Intermediate ) << false;
+  QTest::newRow( "outside the range + c decimal" ) << QString( "3cd6" ) << int( QValidator::Intermediate ) << false;
+  QTest::newRow( "string" ) << QString( "string" ) << int( QValidator::Invalid ) << false;
 
 }
 
@@ -110,12 +111,13 @@ void TestQgsDoubleValidator::validate()
 {
   QFETCH( QString, actualState );
   QFETCH( int, expState );
+  QFETCH( bool, negative );
   QString value;
   int expectedValue;
 
   QLineEdit *lineEdit = new QLineEdit();
 
-  if ( actualState[:2] == "cn" || actualState[:2] == "ln" )
+  if ( negative )
   {
     QgsDoubleValidator *validator = new QgsDoubleValidator( -10000, -4, lineEdit );
   }

--- a/tests/src/gui/testqgsdoublevalidator.cpp
+++ b/tests/src/gui/testqgsdoublevalidator.cpp
@@ -62,9 +62,9 @@ void TestQgsDoubleValidator::validate_data()
   QTest::newRow( "C decimal" ) << QString( "4cd6" ) << int( QValidator::Acceptable );
   QTest::newRow( "locale decimal" ) << QString( "4ld6" ) << int( QValidator::Acceptable );
   QTest::newRow( "locale decimal" ) << QString( "4444ld6" ) << int( QValidator::Acceptable );
-  QTest::newRow( "negative C decimal" ) << QString( "-4cd6" ) << int( QValidator::Acceptable );
-  QTest::newRow( "negative locale decimal" ) << QString( "-4ld6" ) << int( QValidator::Acceptable );
-  QTest::newRow( "negative locale decimal" ) << QString( "-4444ld6" ) << int( QValidator::Acceptable );
+  QTest::newRow( "C negative C decimal" ) << QString( "cn4cd6" ) << int( QValidator::Acceptable );
+  QTest::newRow( "locale negative locale decimal" ) << QString( "ln4ld6" ) << int( QValidator::Acceptable );
+  QTest::newRow( "locale negative locale decimal" ) << QString( "ln4444ld6" ) << int( QValidator::Acceptable );
 
   // QgsDoubleValidator doesn't expect group separator but it tolerates it,
   // so the result will be QValidator::Intermediate and not QValidator::Acceptable
@@ -88,9 +88,9 @@ void TestQgsDoubleValidator::toDouble_data()
   QTest::newRow( "C decimal" ) << QString( "4cd6" ) << 4.6;
   QTest::newRow( "locale decimal" ) << QString( "4ld6" ) << 4.6;
   QTest::newRow( "locale decimal" ) << QString( "4444ld6" ) << 4444.6;
-  QTest::newRow( "negative C decimal" ) << QString( "-4cd6" ) << -4.6;
-  QTest::newRow( "negative locale decimal" ) << QString( "-4ld6" ) << -4.6;
-  QTest::newRow( "negative locale decimal" ) << QString( "-4444ld6" ) << -4444.6;
+  QTest::newRow( "C negative C decimal" ) << QString( "cn4cd6" ) << -4.6;
+  QTest::newRow( "locale negative locale decimal" ) << QString( "ln4ld6" ) << -4.6;
+  QTest::newRow( "locale negative locale decimal" ) << QString( "ln4444ld6" ) << -4444.6;
 
   // QgsDoubleValidator doesn't expect group separator but it tolerates it,
   // so the result will be QValidator::Intermediate and not QValidator::Acceptable
@@ -108,14 +108,23 @@ void TestQgsDoubleValidator::toDouble_data()
 
 void TestQgsDoubleValidator::validate()
 {
-  QLineEdit *lineEdit = new QLineEdit();
-  QgsDoubleValidator *validator = new QgsDoubleValidator( 4, 10000, lineEdit );
-  lineEdit->setValidator( validator );
-
   QFETCH( QString, actualState );
   QFETCH( int, expState );
   QString value;
   int expectedValue;
+
+  QLineEdit *lineEdit = new QLineEdit();
+
+  if ( actualState[:2] == "cn" || actualState[:2] == "ln" )
+  {
+    QgsDoubleValidator *validator = new QgsDoubleValidator( -10000, -4, lineEdit );
+  }
+  else
+  {
+    QgsDoubleValidator *validator = new QgsDoubleValidator( 4, 10000, lineEdit );
+  }
+
+  lineEdit->setValidator( validator );
 
   const QVector<QLocale>listLocale( {QLocale::English, QLocale::French, QLocale::German, QLocale::Italian} );
   QLocale loc;
@@ -128,7 +137,9 @@ void TestQgsDoubleValidator::validate()
     value = value.replace( "ld", QLocale().decimalPoint() )
             .replace( "cd", QLocale( QLocale::C ).decimalPoint() )
             .replace( "lg", QLocale().groupSeparator() )
-            .replace( "cg", QLocale( QLocale::C ).groupSeparator() );
+            .replace( "cg", QLocale( QLocale::C ).groupSeparator() )
+            .replace( "ln", QLocale().negativeSign() )
+            .replace( "cn", QLocale( QLocale::C ).negativeSign() );
     expectedValue = expState;
     // if the local group separator / decimal point is equal to the C one,
     // expected result will be different for double with test with mixed
@@ -177,7 +188,9 @@ void TestQgsDoubleValidator::toDouble()
     value = value.replace( "ld", QLocale().decimalPoint() )
             .replace( "cd", QLocale( QLocale::C ).decimalPoint() )
             .replace( "lg", QLocale().groupSeparator() )
-            .replace( "cg", QLocale( QLocale::C ).groupSeparator() );
+            .replace( "cg", QLocale( QLocale::C ).groupSeparator() )
+            .replace( "ln", QLocale().negativeSign() )
+            .replace( "cn", QLocale( QLocale::C ).negativeSign() );
     expectedValue = expValue;
     // if the local group separator / decimal point is equal to the C one,
     // expected result will be different for double with test with mixed

--- a/tests/src/gui/testqgsdoublevalidator.cpp
+++ b/tests/src/gui/testqgsdoublevalidator.cpp
@@ -62,6 +62,9 @@ void TestQgsDoubleValidator::validate_data()
   QTest::newRow( "C decimal" ) << QString( "4cd6" ) << int( QValidator::Acceptable );
   QTest::newRow( "locale decimal" ) << QString( "4ld6" ) << int( QValidator::Acceptable );
   QTest::newRow( "locale decimal" ) << QString( "4444ld6" ) << int( QValidator::Acceptable );
+  QTest::newRow( "negative C decimal" ) << QString( "-4cd6" ) << int( QValidator::Acceptable );
+  QTest::newRow( "negative locale decimal" ) << QString( "-4ld6" ) << int( QValidator::Acceptable );
+  QTest::newRow( "negative locale decimal" ) << QString( "-4444ld6" ) << int( QValidator::Acceptable );
 
   // QgsDoubleValidator doesn't expect group separator but it tolerates it,
   // so the result will be QValidator::Intermediate and not QValidator::Acceptable
@@ -85,6 +88,9 @@ void TestQgsDoubleValidator::toDouble_data()
   QTest::newRow( "C decimal" ) << QString( "4cd6" ) << 4.6;
   QTest::newRow( "locale decimal" ) << QString( "4ld6" ) << 4.6;
   QTest::newRow( "locale decimal" ) << QString( "4444ld6" ) << 4444.6;
+  QTest::newRow( "negative C decimal" ) << QString( "-4cd6" ) << -4.6;
+  QTest::newRow( "negative locale decimal" ) << QString( "-4ld6" ) << -4.6;
+  QTest::newRow( "negative locale decimal" ) << QString( "-4444ld6" ) << -4444.6;
 
   // QgsDoubleValidator doesn't expect group separator but it tolerates it,
   // so the result will be QValidator::Intermediate and not QValidator::Acceptable

--- a/tests/src/gui/testqgsdoublevalidator.cpp
+++ b/tests/src/gui/testqgsdoublevalidator.cpp
@@ -119,9 +119,9 @@ void TestQgsDoubleValidator::validate()
   int expectedValue;
 
   if ( negative )
-    validator.setRange( -10000, -4 );
+    validator->setRange( -10000, -4 );
   else
-    validator.setRange( 4, 10000 );
+    validator->setRange( 4, 10000 );
 
   lineEdit->setValidator( validator );
 

--- a/tests/src/gui/testqgsdoublevalidator.cpp
+++ b/tests/src/gui/testqgsdoublevalidator.cpp
@@ -110,7 +110,7 @@ void TestQgsDoubleValidator::toDouble_data()
 void TestQgsDoubleValidator::validate()
 {
   QLineEdit *lineEdit = new QLineEdit();
-  QgsDoubleValidator *validator = new QgsDoubleValidator();
+  QgsDoubleValidator *validator = new QgsDoubleValidator( lineEdit );
 
   QFETCH( QString, actualState );
   QFETCH( int, expState );

--- a/tests/src/gui/testqgsdoublevalidator.cpp
+++ b/tests/src/gui/testqgsdoublevalidator.cpp
@@ -109,22 +109,19 @@ void TestQgsDoubleValidator::toDouble_data()
 
 void TestQgsDoubleValidator::validate()
 {
+  QLineEdit *lineEdit = new QLineEdit();
+  QgsDoubleValidator *validator = new QgsDoubleValidator();
+
   QFETCH( QString, actualState );
   QFETCH( int, expState );
   QFETCH( bool, negative );
   QString value;
   int expectedValue;
 
-  QLineEdit *lineEdit = new QLineEdit();
-
   if ( negative )
-  {
-    QgsDoubleValidator *validator = new QgsDoubleValidator( -10000, -4, lineEdit );
-  }
+    validator.setRange( -10000, -4 );
   else
-  {
-    QgsDoubleValidator *validator = new QgsDoubleValidator( 4, 10000, lineEdit );
-  }
+    validator.setRange( 4, 10000 );
 
   lineEdit->setValidator( validator );
 


### PR DESCRIPTION
Since some locales use the − character [Unicode Character “−” (U+2212)] as negative sign, instead of the - character [Unicode Character “-” (U+002D)]

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
