### PR TITLE
[delimitedtext] Log an info message instead of an error on update

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -1340,9 +1340,7 @@ void QgsDelimitedTextProvider::onFileUpdated()
 {
   if ( !mRescanRequired )
   {
-    QStringList messages;
-    messages.append( tr( "The file has been updated by another application - reloading" ) );
-    reportErrors( messages );
+    QgsMessageLog::logMessage( tr( "The file has been updated by another application - reloading" ), QStringLiteral( "DelimitedText" ),  Qgis::MessageLevel::Info );
     mRescanRequired = true;
     emit dataChanged();
   }

--- a/tests/src/python/test_qgsdelimitedtextprovider_wanted.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider_wanted.py
@@ -1456,11 +1456,8 @@ def test_029_file_watcher():
         "Request 11 did not return any data",
         "Request 13 did not return any data",
         "Request 14 did not return any data",
-        "Errors in file temp_file",
         "The file has been updated by another application - reloading",
-        "Errors in file temp_file",
         "The file has been updated by another application - reloading",
-        "Errors in file temp_file",
         "The file has been updated by another application - reloading",
     ]
     return wanted


### PR DESCRIPTION
## Description

Description
2025-11-26T03:31:36 WARNING Errors in file C:/Users/Andrea/Downloads/test.csv
2025-11-26T03:31:36 WARNING The file has been updated by another application - reloading

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
